### PR TITLE
Add version key to manifest.json

### DIFF
--- a/custom_components/yandextts/manifest.json
+++ b/custom_components/yandextts/manifest.json
@@ -5,4 +5,5 @@
   "requirements": [],
   "dependencies": [],
   "codeowners": []
+  "version": "1.0.0",
 }

--- a/custom_components/yandextts/manifest.json
+++ b/custom_components/yandextts/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/yandextts",
   "requirements": [],
   "dependencies": [],
-  "codeowners": []
-  "version": "1.0.0",
+  "codeowners": [],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
The version key is required from Home Assistant version 2021.6